### PR TITLE
Fixed GNU Getopt dependency to allow build from Maven Central

### DIFF
--- a/apps/pom.xml
+++ b/apps/pom.xml
@@ -24,7 +24,7 @@
 
     <dependency>
       <groupId>gnu-getopt</groupId>
-      <artifactId>getopt</artifactId>
+      <artifactId>java-getopt</artifactId>
       <version>1.0.13</version>
     </dependency>
 


### PR DESCRIPTION
There is a problem with the artifact naming of GNU Getopt which is a dependency used by jradius-apps. At some point the artifact was renamed to `java-getopt` and can no longer be found in Maven Central as `getopt`, causing build failures. 

This PR is a simple one line fix for this problem. 