### PR TITLE
Fixed GNU Getopt dependency to allow build from Maven Central

### DIFF
--- a/apps/pom.xml
+++ b/apps/pom.xml
@@ -23,8 +23,8 @@
     </dependency>
 
     <dependency>
-      <groupId>gnu-getopt</groupId>
-      <artifactId>getopt</artifactId>
+      <groupId>gnu.getopt</groupId>
+      <artifactId>java-getopt</artifactId>
       <version>1.0.13</version>
     </dependency>
 


### PR DESCRIPTION
There is a problem with the artifact naming of GNU Getopt which is a dependency used by jradius-apps. At some point the artifact was renamed from `gnu-getopt.getopt` to  `gnu.getopt.java-getopt` and can no longer be found in Maven Central, causing build failures.

This PR is a simple two line fix for this problem. I've tested a clean build with `mvn -U clean install`

(I previously submitted PR #14 for this, but that one contained an error). 