### PR TITLE
jradius-18; Updating BouncyCastle to v.1.56 (2016) from v.1.44 (2009)

### DIFF
--- a/extended/pom.xml
+++ b/extended/pom.xml
@@ -30,8 +30,8 @@
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15</artifactId>
-      <version>1.44</version>
+      <artifactId>bcprov-jdk15on</artifactId>
+      <version>1.56</version>
     </dependency>
     
   </dependencies>

--- a/extended/src/main/java/net/jradius/client/gui/JRadiusSimulator.java
+++ b/extended/src/main/java/net/jradius/client/gui/JRadiusSimulator.java
@@ -40,6 +40,7 @@ import java.io.PrintStream;
 import java.net.ConnectException;
 import java.net.InetAddress;
 import java.net.URL;
+import java.security.Security;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.ArrayList;
@@ -121,6 +122,7 @@ import net.jradius.standard.WISPrStandard;
 import net.jradius.util.Base64;
 import net.jradius.util.KeyStoreUtil;
 import net.jradius.util.RadiusRandom;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 /**
  * Java Swing Graphical User Interface for the JRadius RADIUS Client.
@@ -243,7 +245,7 @@ public class JRadiusSimulator extends JFrame
     public JRadiusSimulator() {
         super();
  
- //       Security.addProvider(new BouncyCastleProvider());
+        Security.addProvider(new BouncyCastleProvider());
         String version = System.getProperty("java.version");
         if (version.startsWith("1.4")) 
         {

--- a/extended/src/main/java/net/jradius/tls/Certificate.java
+++ b/extended/src/main/java/net/jradius/tls/Certificate.java
@@ -6,9 +6,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Vector;
 
-import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1InputStream;
-import org.bouncycastle.asn1.DERObject;
+import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.x509.X509CertificateStructure;
 
 /**
@@ -41,7 +40,7 @@ public class Certificate
             TlsUtils.readFully(buf, is);
             ByteArrayInputStream bis = new ByteArrayInputStream(buf);
             ASN1InputStream ais = new ASN1InputStream(bis);
-            DERObject o = ais.readObject();
+            ASN1Primitive o = ais.readObject();
             tmp.addElement(X509CertificateStructure.getInstance(o));
             if (bis.available() > 0)
             {
@@ -69,7 +68,7 @@ public class Certificate
         int totalSize = 0;
         for (int i = 0; i < this.certs.length; ++i)
         {
-            byte[] encCert = certs[i].getEncoded(ASN1Encodable.DER);
+            byte[] encCert = certs[i].getEncoded();
             encCerts.addElement(encCert);
             totalSize += encCert.length + 3;
         }

--- a/extended/src/main/java/net/jradius/tls/TlsDHKeyExchange.java
+++ b/extended/src/main/java/net/jradius/tls/TlsDHKeyExchange.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
 
-import org.bouncycastle.asn1.DERBitString;
 import org.bouncycastle.asn1.x509.KeyUsage;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.asn1.x509.X509CertificateStructure;
@@ -242,7 +241,7 @@ class TlsDHKeyExchange implements TlsKeyExchange
             X509Extension ext = exts.getExtension(X509Extensions.KeyUsage);
             if (ext != null)
             {
-                DERBitString ku = KeyUsage.getInstance(ext);
+                KeyUsage ku = KeyUsage.getInstance(ext);
                 int bits = ku.getBytes()[0] & 0xff;
                 if ((bits & keyUsageBits) != keyUsageBits)
                 {

--- a/extended/src/main/java/net/jradius/tls/TlsDSSSigner.java
+++ b/extended/src/main/java/net/jradius/tls/TlsDSSSigner.java
@@ -2,11 +2,11 @@ package net.jradius.tls;
 
 import org.bouncycastle.crypto.CryptoException;
 import org.bouncycastle.crypto.Signer;
+import org.bouncycastle.crypto.digests.NullDigest;
 import org.bouncycastle.crypto.digests.SHA1Digest;
 import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
 import org.bouncycastle.crypto.signers.DSADigestSigner;
 import org.bouncycastle.crypto.signers.DSASigner;
-import org.bouncycastle.jce.provider.util.NullDigest;
 
 class TlsDSSSigner implements TlsSigner
 {

--- a/extended/src/main/java/net/jradius/tls/TlsProtocolHandler.java
+++ b/extended/src/main/java/net/jradius/tls/TlsProtocolHandler.java
@@ -14,6 +14,7 @@ import javax.net.ssl.KeyManager;
 import javax.net.ssl.TrustManager;
 
 import org.bouncycastle.asn1.ASN1Object;
+import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.x509.X509Name;
 import org.bouncycastle.crypto.prng.ThreadedSeedGenerator;
 
@@ -578,7 +579,7 @@ public class TlsProtocolHandler
                         while (bis.available() > 0)
                         {
                             byte[] dnBytes = TlsUtils.readOpaque16(bis);
-                            authorityDNs.add(X509Name.getInstance(ASN1Object.fromByteArray(dnBytes)));
+                            authorityDNs.add(X509Name.getInstance(ASN1Primitive.fromByteArray(dnBytes)));
                         }
 
                         this.tlsClient.processServerCertificateRequest(types, authorityDNs);

--- a/extended/src/main/java/net/jradius/tls/TlsRSAKeyExchange.java
+++ b/extended/src/main/java/net/jradius/tls/TlsRSAKeyExchange.java
@@ -141,7 +141,7 @@ class TlsRSAKeyExchange implements TlsKeyExchange
             X509Extension ext = exts.getExtension(X509Extensions.KeyUsage);
             if (ext != null)
             {
-                DERBitString ku = KeyUsage.getInstance(ext);
+                KeyUsage ku = KeyUsage.getInstance(ext);
                 int bits = ku.getBytes()[0] & 0xff;
                 if ((bits & keyUsageBits) != keyUsageBits)
                 {

--- a/extended/src/main/java/net/jradius/tls/TlsRSASigner.java
+++ b/extended/src/main/java/net/jradius/tls/TlsRSASigner.java
@@ -2,11 +2,11 @@ package net.jradius.tls;
 
 import org.bouncycastle.crypto.CryptoException;
 import org.bouncycastle.crypto.Signer;
+import org.bouncycastle.crypto.digests.NullDigest;
 import org.bouncycastle.crypto.encodings.PKCS1Encoding;
 import org.bouncycastle.crypto.engines.RSABlindedEngine;
 import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
 import org.bouncycastle.crypto.signers.GenericSigner;
-import org.bouncycastle.jce.provider.util.NullDigest;
 
 class TlsRSASigner implements TlsSigner
 {

--- a/extended/src/main/java/net/jradius/tls/TlsSRPKeyExchange.java
+++ b/extended/src/main/java/net/jradius/tls/TlsSRPKeyExchange.java
@@ -225,7 +225,7 @@ class TlsSRPKeyExchange implements TlsKeyExchange
             X509Extension ext = exts.getExtension(X509Extensions.KeyUsage);
             if (ext != null)
             {
-                DERBitString ku = KeyUsage.getInstance(ext);
+                KeyUsage ku = KeyUsage.getInstance(ext);
                 int bits = ku.getBytes()[0] & 0xff;
                 if ((bits & keyUsageBits) != keyUsageBits)
                 {

--- a/extended/src/main/java/net/jradius/util/KeyStoreUtil.java
+++ b/extended/src/main/java/net/jradius/util/KeyStoreUtil.java
@@ -36,8 +36,7 @@ import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.openssl.PEMReader;
-import org.bouncycastle.openssl.PasswordFinder;
+import org.bouncycastle.util.io.pem.PemReader;
 
 public class KeyStoreUtil 
 {
@@ -57,15 +56,11 @@ public class KeyStoreUtil
 
 		if (type.equalsIgnoreCase("pem"))
 		{
-			PEMReader pemReader = new PEMReader(new InputStreamReader(in), new PasswordFinder() {
-				public char[] getPassword() {
-					return pwd;
-				}
-			});
+			PemReader pemReader = new PemReader(new InputStreamReader(in));
 			
 			Object obj, keyObj=null, certObj=null, keyPair=null;
 
-			while ((obj = pemReader.readObject()) != null)
+			while ((obj = pemReader.readPemObject()) != null)
 			{
 				if (obj instanceof X509Certificate) certObj = obj;
 				else if (obj instanceof PrivateKey) keyObj = obj;
@@ -141,14 +136,10 @@ public class KeyStoreUtil
 	{
 		loadBC();
 
-        PEMReader pemReader = new PEMReader(new InputStreamReader(in), new PasswordFinder() {
-			public char[] getPassword() {
-				return pwd;
-			}
-		});
+        PemReader pemReader = new PemReader(new InputStreamReader(in));
 
 		Object obj;
-		while ((obj = pemReader.readObject()) != null)
+		while ((obj = pemReader.readPemObject()) != null)
 		{
 			if (obj instanceof X509Certificate)
 			{


### PR DESCRIPTION
Nothing too exciting here - just updating to the latest BouncyCastle provider jar.  Also, enabling BC when running the JRadiusSimulator so that all the options work by default.