### PR TITLE
Add support for server certificate authenticity verification 

### DIFF
--- a/extended/src/main/java/net/jradius/client/auth/EAPTLSAuthenticator.java
+++ b/extended/src/main/java/net/jradius/client/auth/EAPTLSAuthenticator.java
@@ -42,7 +42,7 @@ import net.jradius.exception.RadiusException;
 import net.jradius.log.RadiusLog;
 import net.jradius.packet.RadiusPacket;
 import net.jradius.tls.AlwaysValidVerifyer;
-import net.jradius.tls.Certificate;
+import net.jradius.tls.CertificateChain;
 import net.jradius.tls.DefaultTlsClient;
 import net.jradius.tls.TlsProtocolHandler;
 import net.jradius.util.KeyStoreUtil;
@@ -186,7 +186,7 @@ public class EAPTLSAuthenticator extends EAPAuthenticator
 			            certs[i] = (X509CertificateStructure)tmp.elementAt(i);
 			        }
 
-					tlsClient.enableClientAuthentication(new Certificate(certs), createKey(key.getEncoded()));
+					tlsClient.enableClientAuthentication(new CertificateChain(certs), createKey(key.getEncoded()));
 		        }
 			}
 			catch (Exception e)

--- a/extended/src/main/java/net/jradius/client/auth/EAPTLSAuthenticator.java
+++ b/extended/src/main/java/net/jradius/client/auth/EAPTLSAuthenticator.java
@@ -37,17 +37,7 @@ import javax.net.ssl.KeyManager;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509KeyManager;
 
-import net.jradius.client.RadiusClient;
-import net.jradius.exception.RadiusException;
-import net.jradius.log.RadiusLog;
-import net.jradius.packet.RadiusPacket;
-import net.jradius.tls.AlwaysValidVerifyer;
-import net.jradius.tls.CertificateChain;
-import net.jradius.tls.DefaultTlsClient;
-import net.jradius.tls.TlsProtocolHandler;
-import net.jradius.util.KeyStoreUtil;
 import org.bouncycastle.asn1.ASN1Encodable;
-
 import org.bouncycastle.asn1.ASN1InputStream;
 import org.bouncycastle.asn1.ASN1Integer;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
@@ -65,8 +55,8 @@ import org.bouncycastle.asn1.sec.ECPrivateKey;
 import org.bouncycastle.asn1.sec.SECNamedCurves;
 import org.bouncycastle.asn1.teletrust.TeleTrusTNamedCurves;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
+import org.bouncycastle.asn1.x509.Certificate;
 import org.bouncycastle.asn1.x509.DSAParameter;
-import org.bouncycastle.asn1.x509.X509CertificateStructure;
 import org.bouncycastle.asn1.x9.X962NamedCurves;
 import org.bouncycastle.asn1.x9.X962Parameters;
 import org.bouncycastle.asn1.x9.X9ECParameters;
@@ -82,10 +72,20 @@ import org.bouncycastle.crypto.params.ElGamalParameters;
 import org.bouncycastle.crypto.params.ElGamalPrivateKeyParameters;
 import org.bouncycastle.crypto.params.RSAPrivateCrtKeyParameters;
 
+import net.jradius.client.RadiusClient;
+import net.jradius.exception.RadiusException;
+import net.jradius.log.RadiusLog;
+import net.jradius.packet.RadiusPacket;
+import net.jradius.tls.AlwaysValidVerifyer;
+import net.jradius.tls.CertificateChain;
+import net.jradius.tls.DefaultTlsClient;
+import net.jradius.tls.TlsProtocolHandler;
+import net.jradius.util.KeyStoreUtil;
+
 
 /**
  * EAP-TLS Authentication (and TLS Tunnel support).
- * 
+ *
  * @author David Bird
  */
 public class EAPTLSAuthenticator extends EAPAuthenticator
@@ -95,22 +95,22 @@ public class EAPTLSAuthenticator extends EAPAuthenticator
     private String keyFileType;
     private String keyFile;
     private String keyPassword;
-    
+
     private String caFileType;
     private String caFile;
     private String caPassword;
-    
+
     private Boolean trustAll = Boolean.FALSE;
 
     private ByteArrayOutputStream bout;
     private ByteArrayInputStream bin;
 
-    private TlsProtocolHandler handler = new TlsProtocolHandler();
-    private AlwaysValidVerifyer verifyer = new AlwaysValidVerifyer();
-    
+    private final TlsProtocolHandler handler = new TlsProtocolHandler();
+    private final AlwaysValidVerifyer verifyer = new AlwaysValidVerifyer();
+
     private DefaultTlsClient tlsClient = null;
-    
-    private ByteBuffer receivedEAP = ByteBuffer.allocate(10000000);
+
+    private final ByteBuffer receivedEAP = ByteBuffer.allocate(10000000);
 
     private KeyManager keyManagers[] = null;
     private TrustManager trustManagers[] = null;
@@ -124,10 +124,11 @@ public class EAPTLSAuthenticator extends EAPAuthenticator
         caFileType = "pkcs12";
         caPassword = "";
     }
-    
+
     /* (non-Javadoc)
      * @see net.sf.jradius.client.auth.RadiusAuthenticator#setupRequest(net.sf.jradius.client.RadiusClient, net.sf.jradius.packet.RadiusPacket)
      */
+    @Override
     public void setupRequest(RadiusClient c, RadiusPacket p) throws RadiusException, NoSuchAlgorithmException
     {
         super.setupRequest(c, p);
@@ -136,8 +137,8 @@ public class EAPTLSAuthenticator extends EAPAuthenticator
 
     /**
      * Initializs the SSL layer.
-     * @throws Exception 
-     * @throws FileNotFoundException 
+     * @throws Exception
+     * @throws FileNotFoundException
      */
     public void init() throws RadiusException
     {
@@ -147,8 +148,8 @@ public class EAPTLSAuthenticator extends EAPAuthenticator
 	        {
 	        	keyManagers = KeyStoreUtil.loadKeyManager(getKeyFileType(), new FileInputStream(getKeyFile()), getKeyPassword());
 	        }
-	
-	        if (getTrustAll().booleanValue()) 
+
+	        if (getTrustAll().booleanValue())
 	        {
 	        	trustManagers = KeyStoreUtil.trustAllManager();
 	        }
@@ -156,14 +157,14 @@ public class EAPTLSAuthenticator extends EAPAuthenticator
 	        {
 	        	trustManagers = KeyStoreUtil.loadTrustManager(getCaFileType(), new FileInputStream(getCaFile()), getCaPassword());
 	        }
-	        
+
 			tlsClient = new DefaultTlsClient(verifyer);
 
 			try
 			{
 				if (keyManagers != null && keyManagers.length > 0)
 				{
-					X509CertificateStructure[] certs = null;
+					Certificate[] certs = null;
 					X509Certificate[] certChain = ((X509KeyManager)keyManagers[0]).getCertificateChain("");
 					PrivateKey key = ((X509KeyManager)keyManagers[0]).getPrivateKey("");
 					Vector tmp = new Vector();
@@ -173,17 +174,17 @@ public class EAPTLSAuthenticator extends EAPAuthenticator
 			            ByteArrayInputStream bis = new ByteArrayInputStream(cert.getEncoded());
 			            ASN1InputStream ais = new ASN1InputStream(bis);
 			            ASN1Primitive o = ais.readObject();
-			            tmp.addElement(X509CertificateStructure.getInstance(o));
+			            tmp.addElement(Certificate.getInstance(o));
 			            if (bis.available() > 0)
 			            {
 			                throw new IllegalArgumentException(
 			                    "Sorry, there is garbage data left after the certificate");
 			            }
 			        }
-			        certs = new X509CertificateStructure[tmp.size()];
+			        certs = new Certificate[tmp.size()];
 			        for (int i = 0; i < tmp.size(); i++)
 			        {
-			            certs[i] = (X509CertificateStructure)tmp.elementAt(i);
+			            certs[i] = (Certificate)tmp.elementAt(i);
 			        }
 
 					tlsClient.enableClientAuthentication(new CertificateChain(certs), createKey(key.getEncoded()));
@@ -208,14 +209,14 @@ public class EAPTLSAuthenticator extends EAPAuthenticator
         {
             KeyManager keyManagers[] = null;
             TrustManager trustManagers[] = null;
-            
+
             if (getKeyFile() != null)
             {
                 KeyStore ksKeys = KeyStore.getInstance(getKeyFileType());
                 ksKeys.load(new FileInputStream(getKeyFile()), getKeyPassword().toCharArray());
                 KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
                 kmf.init(ksKeys, getKeyPassword().toCharArray());
-                
+
                 keyManagers = kmf.getKeyManagers();
             }
 
@@ -225,12 +226,12 @@ public class EAPTLSAuthenticator extends EAPAuthenticator
                 caKeys.load(new FileInputStream(getCaFile()), getCaPassword().toCharArray());
                 TrustManagerFactory tmf = TrustManagerFactory.getInstance("SunX509");
                 tmf.init(caKeys);
-                
+
                 trustManagers = tmf.getTrustManagers();
             }
-            else 
+            else
             {
-                if (getTrustAll().booleanValue()) 
+                if (getTrustAll().booleanValue())
                 {
                     trustManagers = new TrustManager[]{ new NoopX509TrustManager() };
                 }
@@ -246,6 +247,7 @@ public class EAPTLSAuthenticator extends EAPAuthenticator
 	/**
      * @see net.jradius.client.auth.RadiusAuthenticator#getAuthName()
      */
+    @Override
     public String getAuthName()
     {
         return NAME;
@@ -259,17 +261,17 @@ public class EAPTLSAuthenticator extends EAPAuthenticator
     protected static final int TLS_CLIENT_HELLO = 0;
     protected static final int TLS_SERVER_HELLO = 1;
     protected static final int TLS_APP_DATA = 2;
-    
+
     protected byte[] eapFragmentedReply = null;
     protected int eapFragmentedOffset = 0;
-    
+
     ByteArrayOutputStream appOutput = new ByteArrayOutputStream();
-    
+
     public void setServerMode()
     {
     	state = TLS_SERVER_HELLO;
     }
-    
+
     public void putAppBuffer(byte []b)
     {
         try
@@ -294,21 +296,22 @@ public class EAPTLSAuthenticator extends EAPAuthenticator
         }
     }
 
-    protected byte[] getAppBuffer() 
+    protected byte[] getAppBuffer()
     {
         byte b[] = appOutput.toByteArray();
         appOutput = new ByteArrayOutputStream();
         return b;
     }
 
+    @Override
     public byte[] doEAPType(byte id, byte[] data) throws RadiusException
     {
         ByteBuffer bb = ByteBuffer.wrap(data);
-        
+
         byte dflags = bb.get();
         byte flags = 0;
         int dlen = 0;
-        
+
         try
         {
             if ((dflags & TLS_HAS_LENGTH) != 0)
@@ -349,14 +352,14 @@ public class EAPTLSAuthenticator extends EAPAuthenticator
                 case 1:
                 {
                     receivedEAP.flip();
-                    ByteArrayInputStream is = new ByteArrayInputStream(receivedEAP.array(), 
-                    		receivedEAP.position(), 
+                    ByteArrayInputStream is = new ByteArrayInputStream(receivedEAP.array(),
+                    		receivedEAP.position(),
                     		receivedEAP.remaining());
                     ByteArrayOutputStream os = new ByteArrayOutputStream();
                     short s = handler.updateConnectState(is, os);
                     data = os.toByteArray();
                     receivedEAP.clear();
-                    if (s == TlsProtocolHandler.CS_DONE) 
+                    if (s == TlsProtocolHandler.CS_DONE)
                     {
                     	state = 2;
                     }
@@ -370,8 +373,8 @@ public class EAPTLSAuthenticator extends EAPAuthenticator
                 case 2:
                 {
                     receivedEAP.flip();
-                    ByteArrayInputStream is = new ByteArrayInputStream(receivedEAP.array(), 
-                    		receivedEAP.position(), 
+                    ByteArrayInputStream is = new ByteArrayInputStream(receivedEAP.array(),
+                    		receivedEAP.position(),
                     		receivedEAP.remaining());
 
                     ByteArrayOutputStream os = new ByteArrayOutputStream();
@@ -390,19 +393,19 @@ public class EAPTLSAuthenticator extends EAPAuthenticator
                     {
                         RadiusLog.error(e.getMessage(), e);
                     }
-                    
+
                     data = os.toByteArray();
                     receivedEAP.clear();
                 }
                 break;
             }
-            
+
             if (data != null && data.length > 1024)
             {
                 eapFragmentedReply = data;
                 return nextFragment();
             }
-            
+
             return tlsResponse(flags, data);
         }
         catch (Exception e)
@@ -410,13 +413,13 @@ public class EAPTLSAuthenticator extends EAPAuthenticator
             throw new RadiusException(e);
         }
     }
-    
+
     protected byte[] nextFragment()
     {
         int left = eapFragmentedReply.length - eapFragmentedOffset;
         byte flags = (byte)0;
-        
-        if (left > 1024) 
+
+        if (left > 1024)
         {
             left = 1024;
             flags |= TLS_MORE_FRAGMENTS;
@@ -425,13 +428,13 @@ public class EAPTLSAuthenticator extends EAPAuthenticator
         byte[] data = new byte[left];
         System.arraycopy(eapFragmentedReply, eapFragmentedOffset, data, 0, data.length);
         eapFragmentedOffset += data.length;
-        
+
         if (eapFragmentedReply.length == eapFragmentedOffset)
         {
             eapFragmentedReply = null;
             eapFragmentedOffset = 0;
         }
-        
+
         return tlsResponse(flags, data);
     }
 
@@ -439,10 +442,10 @@ public class EAPTLSAuthenticator extends EAPAuthenticator
     {
         int length = 1;
 
-        if (data != null && data.length > 0) 
+        if (data != null && data.length > 0)
         {
         	length += data.length;
-        	if (flags != 0) 
+        	if (flags != 0)
         	{
         		length += 4;
         		flags |= TLS_HAS_LENGTH;
@@ -451,15 +454,15 @@ public class EAPTLSAuthenticator extends EAPAuthenticator
 
         byte[] response = new byte[length];
         response[0] = flags;
-        
-        if (data != null && data.length > 0) 
+
+        if (data != null && data.length > 0)
         {
-        	if (flags == 0) 
+        	if (flags == 0)
         	{
         		System.arraycopy(data, 0, response, 1, data.length);
         	}
-        	else 
-        	{ 
+        	else
+        	{
         		length -= 1;
                 response[1] = (byte) (eapFragmentedReply.length >> 24 & 0xFF);
                 response[2] = (byte) (eapFragmentedReply.length >> 16 & 0xFF);
@@ -471,7 +474,7 @@ public class EAPTLSAuthenticator extends EAPAuthenticator
 
         return response;
     }
-    
+
     protected boolean doTunnelAuthentication(byte id, byte[] in) throws Throwable
     {
         // Not needed for EAP-TLS, but dependent protocols (PEAP, EAP-TTLS) implement this
@@ -537,7 +540,7 @@ public class EAPTLSAuthenticator extends EAPAuthenticator
     {
         this.caPassword = caPassword;
     }
-    
+
     public Boolean getTrustAll()
     {
         return trustAll;
@@ -548,10 +551,10 @@ public class EAPTLSAuthenticator extends EAPAuthenticator
         this.trustAll = trustAll;
     }
 
-    
+
     /**
      * Create a private key parameter from a PKCS8 PrivateKeyInfo encoding.
-     * 
+     *
      * @param privateKeyInfoData the PrivateKeyInfo encoding
      * @return a suitable private key parameter
      * @throws IOException on an error decoding the key
@@ -567,7 +570,7 @@ public class EAPTLSAuthenticator extends EAPAuthenticator
 
     /**
      * Create a private key parameter from a PKCS8 PrivateKeyInfo encoding read from a stream.
-     * 
+     *
      * @param inStr the stream to read the PrivateKeyInfo encoding from
      * @return a suitable private key parameter
      * @throws IOException on an error decoding the key
@@ -583,7 +586,7 @@ public class EAPTLSAuthenticator extends EAPAuthenticator
 
     /**
      * Create a private key parameter from the passed in PKCS8 PrivateKeyInfo object.
-     * 
+     *
      * @param keyInfo the PrivateKeyInfo object containing the key material
      * @return a suitable private key parameter
      * @throws IOException on an error decoding the key
@@ -698,7 +701,7 @@ public class EAPTLSAuthenticator extends EAPAuthenticator
     }
     */
 
-	protected boolean isCertificateRequired() 
+	protected boolean isCertificateRequired()
 	{
 		return true;
 	}

--- a/extended/src/main/java/net/jradius/tls/AlwaysValidVerifyer.java
+++ b/extended/src/main/java/net/jradius/tls/AlwaysValidVerifyer.java
@@ -1,10 +1,10 @@
 package net.jradius.tls;
 
-import org.bouncycastle.asn1.x509.X509CertificateStructure;
+import org.bouncycastle.asn1.x509.Certificate;
 
 /**
  * A certificate verifyer, that will always return true.
- * 
+ *
  * <pre>
  * DO NOT USE THIS FILE UNLESS YOU KNOW EXACTLY WHAT YOU ARE DOING.
  * </pre>
@@ -13,10 +13,10 @@ public class AlwaysValidVerifyer implements CertificateVerifyer
 {
     /**
      * Return true.
-     * 
+     *
      * @see org.bouncycastle.crypto.tls.CertificateVerifyer#isValid(org.bouncycastle.asn1.x509.X509CertificateStructure[])
      */
-    public boolean isValid(X509CertificateStructure[] certs)
+    public boolean isValid(Certificate[] certs)
     {
         return true;
     }

--- a/extended/src/main/java/net/jradius/tls/CertificateChain.java
+++ b/extended/src/main/java/net/jradius/tls/CertificateChain.java
@@ -13,7 +13,7 @@ import org.bouncycastle.asn1.x509.X509CertificateStructure;
 /**
  * A representation for a certificate chain as used by a tls server.
  */
-public class Certificate
+public class CertificateChain
 {
     /**
      * The certificates.
@@ -27,7 +27,7 @@ public class Certificate
      * @return A Certificate object with the certs, the server has sended.
      * @throws IOException If something goes wrong during parsing.
      */
-    public static Certificate parse(InputStream is) throws IOException
+    public static CertificateChain parse(InputStream is) throws IOException
     {
         X509CertificateStructure[] certs;
         int left = TlsUtils.readUint24(is);
@@ -53,7 +53,7 @@ public class Certificate
         {
             certs[i] = (X509CertificateStructure)tmp.elementAt(i);
         }
-        return new Certificate(certs);
+        return new CertificateChain(certs);
     }
 
     /**
@@ -88,7 +88,7 @@ public class Certificate
      * 
      * @param certs The certs the chain should contain.
      */
-    public Certificate(X509CertificateStructure[] certs)
+    public CertificateChain(X509CertificateStructure[] certs)
     {
         this.certs = certs;
     }

--- a/extended/src/main/java/net/jradius/tls/CertificateChain.java
+++ b/extended/src/main/java/net/jradius/tls/CertificateChain.java
@@ -11,7 +11,7 @@ import java.util.Vector;
 
 import org.bouncycastle.asn1.ASN1InputStream;
 import org.bouncycastle.asn1.ASN1Primitive;
-import org.bouncycastle.asn1.x509.X509CertificateStructure;
+import org.bouncycastle.asn1.x509.Certificate;
 
 /**
  * A representation for a certificate chain as used by a tls server.
@@ -21,7 +21,7 @@ public class CertificateChain
     /**
      * The certificates.
      */
-    protected X509CertificateStructure[] certs;
+    protected Certificate[] certs;
 
     /**
      * Parse the ServerCertificate message.
@@ -32,7 +32,7 @@ public class CertificateChain
      */
     public static CertificateChain parse(InputStream is) throws IOException
     {
-        X509CertificateStructure[] certs;
+        Certificate[] certs;
         int left = TlsUtils.readUint24(is);
         Vector tmp = new Vector();
         while (left > 0)
@@ -44,17 +44,17 @@ public class CertificateChain
             ByteArrayInputStream bis = new ByteArrayInputStream(buf);
             ASN1InputStream ais = new ASN1InputStream(bis);
             ASN1Primitive o = ais.readObject();
-            tmp.addElement(X509CertificateStructure.getInstance(o));
+            tmp.addElement(Certificate.getInstance(o));
             if (bis.available() > 0)
             {
                 throw new IllegalArgumentException(
                     "Sorry, there is garbage data left after the certificate");
             }
         }
-        certs = new X509CertificateStructure[tmp.size()];
+        certs = new Certificate[tmp.size()];
         for (int i = 0; i < tmp.size(); i++)
         {
-            certs[i] = (X509CertificateStructure)tmp.elementAt(i);
+            certs[i] = (Certificate)tmp.elementAt(i);
         }
         return new CertificateChain(certs);
     }
@@ -91,7 +91,7 @@ public class CertificateChain
      *
      * @param certs The certs the chain should contain.
      */
-    public CertificateChain(X509CertificateStructure[] certs)
+    public CertificateChain(Certificate[] certs)
     {
         this.certs = certs;
     }
@@ -99,9 +99,9 @@ public class CertificateChain
     /**
      * @return An array which contains the certs, this chain contains.
      */
-    public X509CertificateStructure[] getCerts()
+    public Certificate[] getCerts()
     {
-        X509CertificateStructure[] result = new X509CertificateStructure[certs.length];
+        Certificate[] result = new Certificate[certs.length];
         System.arraycopy(certs, 0, result, 0, certs.length);
         return result;
     }
@@ -109,7 +109,7 @@ public class CertificateChain
     public X509Certificate[] toX509() throws IOException, CertificateException {
         X509Certificate[] x509 = new X509Certificate[certs.length];
         for (int i = 0; i < certs.length; i++) {
-            X509CertificateStructure cert = certs[i];
+            Certificate cert = certs[i];
             InputStream in = new ByteArrayInputStream(cert.getEncoded());
             CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
             x509[i] = (X509Certificate)certFactory.generateCertificate(in);

--- a/extended/src/main/java/net/jradius/tls/CertificateChain.java
+++ b/extended/src/main/java/net/jradius/tls/CertificateChain.java
@@ -4,6 +4,9 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
 import java.util.Vector;
 
 import org.bouncycastle.asn1.ASN1InputStream;
@@ -22,7 +25,7 @@ public class CertificateChain
 
     /**
      * Parse the ServerCertificate message.
-     * 
+     *
      * @param is The stream where to parse from.
      * @return A Certificate object with the certs, the server has sended.
      * @throws IOException If something goes wrong during parsing.
@@ -58,7 +61,7 @@ public class CertificateChain
 
     /**
      * Encodes version of the ClientCertificate message
-     * 
+     *
      * @param os stream to write the message to
      * @throws IOException If something goes wrong
      */
@@ -85,7 +88,7 @@ public class CertificateChain
 
     /**
      * Private constructor from a cert array.
-     * 
+     *
      * @param certs The certs the chain should contain.
      */
     public CertificateChain(X509CertificateStructure[] certs)
@@ -101,5 +104,18 @@ public class CertificateChain
         X509CertificateStructure[] result = new X509CertificateStructure[certs.length];
         System.arraycopy(certs, 0, result, 0, certs.length);
         return result;
+    }
+
+    public X509Certificate[] toX509() throws IOException, CertificateException {
+        X509Certificate[] x509 = new X509Certificate[certs.length];
+        for (int i = 0; i < certs.length; i++) {
+            X509CertificateStructure cert = certs[i];
+            InputStream in = new ByteArrayInputStream(cert.getEncoded());
+            CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
+            x509[i] = (X509Certificate)certFactory.generateCertificate(in);
+            in.close();
+        }
+
+        return x509;
     }
 }

--- a/extended/src/main/java/net/jradius/tls/CertificateVerifyer.java
+++ b/extended/src/main/java/net/jradius/tls/CertificateVerifyer.java
@@ -1,6 +1,6 @@
 package net.jradius.tls;
 
-import org.bouncycastle.asn1.x509.X509CertificateStructure;
+import org.bouncycastle.asn1.x509.Certificate;
 
 /**
  * This should be implemented by any class which can find out, if a given certificate
@@ -12,5 +12,5 @@ public interface CertificateVerifyer
      * @param certs The certs, which are part of the chain.
      * @return True, if the chain is accepted, false otherwise.
      */
-    public boolean isValid(X509CertificateStructure[] certs);
+    public boolean isValid(Certificate[] certs);
 }

--- a/extended/src/main/java/net/jradius/tls/DefaultTlsClient.java
+++ b/extended/src/main/java/net/jradius/tls/DefaultTlsClient.java
@@ -68,7 +68,7 @@ public class DefaultTlsClient implements TlsClient
     private TlsProtocolHandler handler;
 
     // (Optional) details for client-side authentication
-    private Certificate clientCert = new Certificate(new X509CertificateStructure[0]);
+    private CertificateChain clientCert = new CertificateChain(new X509CertificateStructure[0]);
     private AsymmetricKeyParameter clientPrivateKey = null;
     private TlsSigner clientSigner = null;
 
@@ -79,7 +79,7 @@ public class DefaultTlsClient implements TlsClient
         this.verifyer = verifyer;
     }
 
-    public void enableClientAuthentication(Certificate clientCertificate,
+    public void enableClientAuthentication(CertificateChain clientCertificate,
         AsymmetricKeyParameter clientPrivateKey)
     {
         if (clientCertificate == null)
@@ -265,7 +265,7 @@ public class DefaultTlsClient implements TlsClient
         }
     }
 
-    public Certificate getCertificate()
+    public CertificateChain getCertificate()
     {
         return clientCert;
     }

--- a/extended/src/main/java/net/jradius/tls/DefaultTlsClient.java
+++ b/extended/src/main/java/net/jradius/tls/DefaultTlsClient.java
@@ -15,6 +15,8 @@ import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
 import org.bouncycastle.crypto.params.DSAPrivateKeyParameters;
 import org.bouncycastle.crypto.params.RSAKeyParameters;
 
+import net.jradius.tls.TlsKeyExchange.Algorithm;
+
 public class DefaultTlsClient implements TlsClient
 {
     // TODO Add runtime support for this check?
@@ -63,7 +65,7 @@ public class DefaultTlsClient implements TlsClient
     private static final int TLS_SRP_SHA_RSA_WITH_AES_256_CBC_SHA = 0xC021;
     private static final int TLS_SRP_SHA_DSS_WITH_AES_256_CBC_SHA = 0xC022;
 
-    private CertificateVerifyer verifyer;
+    private final CertificateVerifyer verifyer;
 
     private TlsProtocolHandler handler;
 
@@ -169,7 +171,7 @@ public class DefaultTlsClient implements TlsClient
 
     public void notifySessionID(byte[] sessionID)
     {
-        // Currently ignored 
+        // Currently ignored
     }
 
     public void notifySelectedCipherSuite(int selectedCipherSuite)
@@ -195,37 +197,37 @@ public class DefaultTlsClient implements TlsClient
             case TLS_DH_DSS_WITH_3DES_EDE_CBC_SHA:
             case TLS_DH_DSS_WITH_AES_128_CBC_SHA:
             case TLS_DH_DSS_WITH_AES_256_CBC_SHA:
-                return createDHKeyExchange(TlsKeyExchange.KE_DH_DSS);
+                return createDHKeyExchange(TlsKeyExchange.Algorithm.KE_DH_DSS);
 
             case TLS_DH_RSA_WITH_3DES_EDE_CBC_SHA:
             case TLS_DH_RSA_WITH_AES_128_CBC_SHA:
             case TLS_DH_RSA_WITH_AES_256_CBC_SHA:
-                return createDHKeyExchange(TlsKeyExchange.KE_DH_RSA);
+                return createDHKeyExchange(TlsKeyExchange.Algorithm.KE_DH_RSA);
 
             case TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA:
             case TLS_DHE_DSS_WITH_AES_128_CBC_SHA:
             case TLS_DHE_DSS_WITH_AES_256_CBC_SHA:
-                return createDHKeyExchange(TlsKeyExchange.KE_DHE_DSS);
+                return createDHKeyExchange(TlsKeyExchange.Algorithm.KE_DHE_DSS);
 
             case TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA:
             case TLS_DHE_RSA_WITH_AES_128_CBC_SHA:
             case TLS_DHE_RSA_WITH_AES_256_CBC_SHA:
-                return createDHKeyExchange(TlsKeyExchange.KE_DHE_RSA);
+                return createDHKeyExchange(TlsKeyExchange.Algorithm.KE_DHE_RSA);
 
             case TLS_SRP_SHA_WITH_3DES_EDE_CBC_SHA:
             case TLS_SRP_SHA_WITH_AES_128_CBC_SHA:
             case TLS_SRP_SHA_WITH_AES_256_CBC_SHA:
-                return createSRPExchange(TlsKeyExchange.KE_SRP);
+                return createSRPExchange(TlsKeyExchange.Algorithm.KE_SRP);
 
             case TLS_SRP_SHA_RSA_WITH_3DES_EDE_CBC_SHA:
             case TLS_SRP_SHA_RSA_WITH_AES_128_CBC_SHA:
             case TLS_SRP_SHA_RSA_WITH_AES_256_CBC_SHA:
-                return createSRPExchange(TlsKeyExchange.KE_SRP_RSA);
+                return createSRPExchange(TlsKeyExchange.Algorithm.KE_SRP_RSA);
 
             case TLS_SRP_SHA_DSS_WITH_3DES_EDE_CBC_SHA:
             case TLS_SRP_SHA_DSS_WITH_AES_128_CBC_SHA:
             case TLS_SRP_SHA_DSS_WITH_AES_256_CBC_SHA:
-                return createSRPExchange(TlsKeyExchange.KE_SRP_DSS);
+                return createSRPExchange(TlsKeyExchange.Algorithm.KE_SRP_DSS);
 
             default:
                 /*
@@ -242,7 +244,7 @@ public class DefaultTlsClient implements TlsClient
 
     public void processServerCertificateRequest(byte[] certificateTypes, List certificateAuthorities)
     {
-        // TODO There shouldn't be a certificate request for SRP 
+        // TODO There shouldn't be a certificate request for SRP
 
         // TODO Use provided info to choose a certificate in getCertificate()
     }
@@ -317,7 +319,7 @@ public class DefaultTlsClient implements TlsClient
         }
     }
 
-    private TlsKeyExchange createDHKeyExchange(short keyExchange)
+    private TlsKeyExchange createDHKeyExchange(Algorithm keyExchange)
     {
         return new TlsDHKeyExchange(handler, verifyer, keyExchange);
     }
@@ -327,7 +329,7 @@ public class DefaultTlsClient implements TlsClient
         return new TlsRSAKeyExchange(handler, verifyer);
     }
 
-    private TlsKeyExchange createSRPExchange(short keyExchange)
+    private TlsKeyExchange createSRPExchange(Algorithm keyExchange)
     {
         return new TlsSRPKeyExchange(handler, verifyer, keyExchange);
     }

--- a/extended/src/main/java/net/jradius/tls/DefaultTlsClient.java
+++ b/extended/src/main/java/net/jradius/tls/DefaultTlsClient.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.Hashtable;
 import java.util.List;
 
-import org.bouncycastle.asn1.x509.X509CertificateStructure;
+import org.bouncycastle.asn1.x509.Certificate;
 import org.bouncycastle.crypto.BlockCipher;
 import org.bouncycastle.crypto.CryptoException;
 import org.bouncycastle.crypto.digests.SHA1Digest;
@@ -70,7 +70,7 @@ public class DefaultTlsClient implements TlsClient
     private TlsProtocolHandler handler;
 
     // (Optional) details for client-side authentication
-    private CertificateChain clientCert = new CertificateChain(new X509CertificateStructure[0]);
+    private CertificateChain clientCert = new CertificateChain(new Certificate[0]);
     private AsymmetricKeyParameter clientPrivateKey = null;
     private TlsSigner clientSigner = null;
 

--- a/extended/src/main/java/net/jradius/tls/TlsClient.java
+++ b/extended/src/main/java/net/jradius/tls/TlsClient.java
@@ -27,7 +27,7 @@ interface TlsClient
 
     byte[] generateCertificateSignature(byte[] md5andsha1) throws IOException;
 
-    Certificate getCertificate();
+    CertificateChain getCertificate();
 
     TlsCipher createCipher(SecurityParameters securityParameters) throws IOException;
 }

--- a/extended/src/main/java/net/jradius/tls/TlsDHKeyExchange.java
+++ b/extended/src/main/java/net/jradius/tls/TlsDHKeyExchange.java
@@ -31,9 +31,9 @@ class TlsDHKeyExchange implements TlsKeyExchange
     private static final BigInteger ONE = BigInteger.valueOf(1);
     private static final BigInteger TWO = BigInteger.valueOf(2);
 
-    private TlsProtocolHandler handler;
-    private CertificateVerifyer verifyer;
-    private short keyExchange;
+    private final TlsProtocolHandler handler;
+    private final CertificateVerifyer verifyer;
+    private final Algorithm algorithm;
     private TlsSigner tlsSigner;
 
     private AsymmetricKeyParameter serverPublicKey = null;
@@ -41,18 +41,18 @@ class TlsDHKeyExchange implements TlsKeyExchange
     private DHPublicKeyParameters dhAgreeServerPublicKey = null;
     private AsymmetricCipherKeyPair dhAgreeClientKeyPair = null;
 
-    TlsDHKeyExchange(TlsProtocolHandler handler, CertificateVerifyer verifyer, short keyExchange)
+    TlsDHKeyExchange(TlsProtocolHandler handler, CertificateVerifyer verifyer, Algorithm keyExchange)
     {
         switch (keyExchange)
         {
-            case TlsKeyExchange.KE_DH_RSA:
-            case TlsKeyExchange.KE_DH_DSS:
+            case KE_DH_RSA:
+            case KE_DH_DSS:
                 this.tlsSigner = null;
                 break;
-            case TlsKeyExchange.KE_DHE_RSA:
+            case KE_DHE_RSA:
                 this.tlsSigner = new TlsRSASigner();
                 break;
-            case TlsKeyExchange.KE_DHE_DSS:
+            case KE_DHE_DSS:
                 this.tlsSigner = new TlsDSSSigner();
                 break;
             default:
@@ -61,7 +61,7 @@ class TlsDHKeyExchange implements TlsKeyExchange
 
         this.handler = handler;
         this.verifyer = verifyer;
-        this.keyExchange = keyExchange;
+        this.algorithm = keyExchange;
     }
 
     public void skipServerCertificate() throws IOException
@@ -90,7 +90,7 @@ class TlsDHKeyExchange implements TlsKeyExchange
             handler.failWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_internal_error);
         }
 
-        // TODO 
+        // TODO
         /*
          * Perform various checks per RFC2246 7.4.2: "Unless otherwise specified, the
          * signing algorithm for the certificate must be the same as the algorithm for the
@@ -99,9 +99,9 @@ class TlsDHKeyExchange implements TlsKeyExchange
 
         // TODO Should the 'instanceof' tests be replaces with stricter checks on keyInfo.getAlgorithmId()?
 
-        switch (this.keyExchange)
+        switch (this.algorithm)
         {
-            case TlsKeyExchange.KE_DH_DSS:
+            case KE_DH_DSS:
                 if (!(this.serverPublicKey instanceof DHPublicKeyParameters))
                 {
                     handler.failWithError(TlsProtocolHandler.AL_fatal,
@@ -111,7 +111,7 @@ class TlsDHKeyExchange implements TlsKeyExchange
 //                x509Cert.getSignatureAlgorithm();
                 this.dhAgreeServerPublicKey = validateDHPublicKey((DHPublicKeyParameters)this.serverPublicKey);
                 break;
-            case TlsKeyExchange.KE_DH_RSA:
+            case KE_DH_RSA:
                 if (!(this.serverPublicKey instanceof DHPublicKeyParameters))
                 {
                     handler.failWithError(TlsProtocolHandler.AL_fatal,
@@ -121,7 +121,7 @@ class TlsDHKeyExchange implements TlsKeyExchange
 //              x509Cert.getSignatureAlgorithm();
                 this.dhAgreeServerPublicKey = validateDHPublicKey((DHPublicKeyParameters)this.serverPublicKey);
                 break;
-            case TlsKeyExchange.KE_DHE_RSA:
+            case KE_DHE_RSA:
                 if (!(this.serverPublicKey instanceof RSAKeyParameters))
                 {
                     handler.failWithError(TlsProtocolHandler.AL_fatal,
@@ -129,7 +129,7 @@ class TlsDHKeyExchange implements TlsKeyExchange
                 }
                 validateKeyUsage(x509Cert, KeyUsage.digitalSignature);
                 break;
-            case TlsKeyExchange.KE_DHE_DSS:
+            case KE_DHE_DSS:
                 if (!(this.serverPublicKey instanceof DSAPublicKeyParameters))
                 {
                     handler.failWithError(TlsProtocolHandler.AL_fatal,
@@ -286,5 +286,9 @@ class TlsDHKeyExchange implements TlsKeyExchange
         // TODO See RFC 2631 for more discussion of Diffie-Hellman validation
 
         return key;
+    }
+
+    public Algorithm getAlgorithm() {
+        return algorithm;
     }
 }

--- a/extended/src/main/java/net/jradius/tls/TlsDHKeyExchange.java
+++ b/extended/src/main/java/net/jradius/tls/TlsDHKeyExchange.java
@@ -69,7 +69,7 @@ class TlsDHKeyExchange implements TlsKeyExchange
         handler.failWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_unexpected_message);
     }
 
-    public void processServerCertificate(Certificate serverCertificate) throws IOException
+    public void processServerCertificate(CertificateChain serverCertificate) throws IOException
     {
         X509CertificateStructure x509Cert = serverCertificate.certs[0];
         SubjectPublicKeyInfo keyInfo = x509Cert.getSubjectPublicKeyInfo();

--- a/extended/src/main/java/net/jradius/tls/TlsDHKeyExchange.java
+++ b/extended/src/main/java/net/jradius/tls/TlsDHKeyExchange.java
@@ -4,11 +4,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
 
+import org.bouncycastle.asn1.x509.Certificate;
+import org.bouncycastle.asn1.x509.Extensions;
 import org.bouncycastle.asn1.x509.KeyUsage;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
-import org.bouncycastle.asn1.x509.X509CertificateStructure;
-import org.bouncycastle.asn1.x509.X509Extension;
-import org.bouncycastle.asn1.x509.X509Extensions;
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
 import org.bouncycastle.crypto.Signer;
 import org.bouncycastle.crypto.agreement.DHBasicAgreement;
@@ -71,7 +70,7 @@ class TlsDHKeyExchange implements TlsKeyExchange
 
     public void processServerCertificate(CertificateChain serverCertificate) throws IOException
     {
-        X509CertificateStructure x509Cert = serverCertificate.certs[0];
+        Certificate x509Cert = serverCertificate.certs[0];
         SubjectPublicKeyInfo keyInfo = x509Cert.getSubjectPublicKeyInfo();
 
         try
@@ -233,21 +232,17 @@ class TlsDHKeyExchange implements TlsKeyExchange
         return BigIntegers.asUnsignedByteArray(agreement);
     }
 
-    private void validateKeyUsage(X509CertificateStructure c, int keyUsageBits) throws IOException
+    private void validateKeyUsage(Certificate c, int keyUsageBits) throws IOException
     {
-        X509Extensions exts = c.getTBSCertificate().getExtensions();
+        Extensions exts = c.getTBSCertificate().getExtensions();
         if (exts != null)
         {
-            X509Extension ext = exts.getExtension(X509Extensions.KeyUsage);
-            if (ext != null)
+            KeyUsage ku = KeyUsage.fromExtensions(exts);
+            int bits = ku.getBytes()[0] & 0xff;
+            if ((bits & keyUsageBits) != keyUsageBits)
             {
-                KeyUsage ku = KeyUsage.getInstance(ext);
-                int bits = ku.getBytes()[0] & 0xff;
-                if ((bits & keyUsageBits) != keyUsageBits)
-                {
-                    handler.failWithError(TlsProtocolHandler.AL_fatal,
-                        TlsProtocolHandler.AP_certificate_unknown);
-                }
+                handler.failWithError(TlsProtocolHandler.AL_fatal,
+                    TlsProtocolHandler.AP_certificate_unknown);
             }
         }
     }

--- a/extended/src/main/java/net/jradius/tls/TlsKeyExchange.java
+++ b/extended/src/main/java/net/jradius/tls/TlsKeyExchange.java
@@ -8,18 +8,34 @@ import java.io.InputStream;
  */
 interface TlsKeyExchange
 {
-    static final short KE_RSA = 1;
-//    static final short KE_RSA_EXPORT = 2;
-    static final short KE_DHE_DSS = 3;
-//    static final short KE_DHE_DSS_EXPORT = 4;
-    static final short KE_DHE_RSA = 5;
-//    static final short KE_DHE_RSA_EXPORT = 6;
-    static final short KE_DH_DSS = 7;
-    static final short KE_DH_RSA = 8;
-//    static final short KE_DH_anon = 9;
-    static final short KE_SRP = 10;
-    static final short KE_SRP_DSS = 11;
-    static final short KE_SRP_RSA = 12;
+    enum Algorithm {
+
+       KE_RSA("RSA", 1),
+       KE_DHE_DSS("DHE_DSS", 3),
+       KE_DHE_RSA("DHE_RSA", 5),
+       KE_DH_DSS("DH_DSS", 7),
+       KE_DH_RSA("DH_RSA", 8),
+       KE_SRP("SRP", 10),
+       KE_SRP_DSS("SRP_DSS", 11),
+       KE_SRP_RSA("SRP_RSA", 12);
+
+       private final String name;
+       private final int id;
+
+       Algorithm(String name, int id) {
+           this.name = name;
+           this.id = id;
+       }
+
+       public String getName() {
+           return name;
+       }
+
+       public int getId() {
+           return id;
+       }
+
+    }
 
     void skipServerCertificate() throws IOException;
 
@@ -33,4 +49,6 @@ interface TlsKeyExchange
     byte[] generateClientKeyExchange() throws IOException;
 
     byte[] generatePremasterSecret() throws IOException;
+
+    Algorithm getAlgorithm();
 }

--- a/extended/src/main/java/net/jradius/tls/TlsKeyExchange.java
+++ b/extended/src/main/java/net/jradius/tls/TlsKeyExchange.java
@@ -23,7 +23,7 @@ interface TlsKeyExchange
 
     void skipServerCertificate() throws IOException;
 
-    void processServerCertificate(Certificate serverCertificate) throws IOException;
+    void processServerCertificate(CertificateChain serverCertificate) throws IOException;
 
     void skipServerKeyExchange() throws IOException;
 

--- a/extended/src/main/java/net/jradius/tls/TlsProtocolHandler.java
+++ b/extended/src/main/java/net/jradius/tls/TlsProtocolHandler.java
@@ -292,7 +292,7 @@ public class TlsProtocolHandler
                     {
                         // Parse the Certificate message and send to cipher suite
 
-                        Certificate serverCertificate = Certificate.parse(is);
+                        CertificateChain serverCertificate = CertificateChain.parse(is);
 
                         assertEmpty(is);
 
@@ -716,7 +716,7 @@ public class TlsProtocolHandler
         }
     }
 
-    private void sendClientCertificate(Certificate clientCert) throws IOException
+    private void sendClientCertificate(CertificateChain clientCert) throws IOException
     {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         TlsUtils.writeUint8(HP_CERTIFICATE, bos);

--- a/extended/src/main/java/net/jradius/tls/TlsProtocolHandler.java
+++ b/extended/src/main/java/net/jradius/tls/TlsProtocolHandler.java
@@ -6,14 +6,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.security.SecureRandom;
+import java.security.cert.CertificateException;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Hashtable;
 
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
 
-import org.bouncycastle.asn1.ASN1Object;
 import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.x509.X509Name;
 import org.bouncycastle.crypto.prng.ThreadedSeedGenerator;
@@ -109,16 +110,16 @@ public class TlsProtocolHandler
     /*
      * Queues for data from some protocols.
      */
-    private ByteQueue applicationDataQueue = new ByteQueue();
-    private ByteQueue changeCipherSpecQueue = new ByteQueue();
-    private ByteQueue alertQueue = new ByteQueue();
-    private ByteQueue handshakeQueue = new ByteQueue();
+    private final ByteQueue applicationDataQueue = new ByteQueue();
+    private final ByteQueue changeCipherSpecQueue = new ByteQueue();
+    private final ByteQueue alertQueue = new ByteQueue();
+    private final ByteQueue handshakeQueue = new ByteQueue();
 
     /*
      * The Record Stream we use
      */
-    private RecordStream rs;
-    private SecureRandom random;
+    private final RecordStream rs;
+    private final SecureRandom random;
 
     private TlsInputStream tlsInputStream = null;
     private TlsOutputStream tlsOutputStream = null;
@@ -135,10 +136,10 @@ public class TlsProtocolHandler
     private TlsKeyExchange keyExchange = null;
 
     private short connection_state = 0;
-    
+
     private KeyManager[] keyManagers = null;
     private TrustManager[] trustManagers = null;
-    
+
     private boolean isSendCertificate = false;
 
     private static SecureRandom createSecureRandom()
@@ -169,7 +170,7 @@ public class TlsProtocolHandler
         this.random = sr;
     }
 
-    public TlsProtocolHandler() 
+    public TlsProtocolHandler()
     {
     	this.rs = new RecordStream(this);
     	this.random = createSecureRandom();
@@ -179,7 +180,7 @@ public class TlsProtocolHandler
     {
         return random;
     }
-	
+
 	public void setSendCertificate(boolean b)
 	{
 		this.isSendCertificate = b;
@@ -215,7 +216,7 @@ public class TlsProtocolHandler
             default:
                 /*
                  * Uh, we don't know this protocol.
-                 * 
+                 *
                  * RFC2246 defines on page 13, that we should ignore this.
                  */
         }
@@ -297,6 +298,19 @@ public class TlsProtocolHandler
                         assertEmpty(is);
 
                         this.keyExchange.processServerCertificate(serverCertificate);
+
+                        X509TrustManager trustManager = chooseTrustManager(trustManagers);
+
+                        if (trustManager != null) {
+                            try {
+                                trustManager.checkServerTrusted(serverCertificate.toX509(),
+                                                                keyExchange.getAlgorithm().getName());
+                            } catch (CertificateException e) {
+                                // If we encounter a certificate exception it
+                                // is likely the server certificate chain is not trusted..
+                                this.failWithError(AL_fatal, AP_handshake_failure);
+                            }
+                        }
 
                         break;
                     }
@@ -621,7 +635,7 @@ public class TlsProtocolHandler
     {
         /*
          * There is nothing we need to do here.
-         * 
+         *
          * This function could be used for callbacks when application data arrives in the
          * future.
          */
@@ -680,7 +694,7 @@ public class TlsProtocolHandler
 
     /**
      * This method is called, when a change cipher spec message is received.
-     * 
+     *
      * @throws IOException If the message has an invalid content or the handshake is not
      *             in the correct state.
      */
@@ -761,9 +775,9 @@ public class TlsProtocolHandler
 
     /**
      * Connects to the remote system.
-     * @param is 
-     * @param out 
-     * 
+     * @param is
+     * @param out
+     *
      * @param verifyer Will be used when a certificate is received to verify that this
      *            certificate is accepted by the client.
      * @throws IOException If handshake was not successful.
@@ -785,7 +799,7 @@ public class TlsProtocolHandler
 
     /**
      * Connects to the remote system using client authentication
-     * 
+     *
      * @param verifyer Will be used when a certificate is received to verify that this
      *            certificate is accepted by the client.
      * @param clientCertificate The client's certificate to be provided to the remote
@@ -808,13 +822,13 @@ public class TlsProtocolHandler
 
         rs.setInputStream(is);
         rs.setOutputStream(out);
-        
+
         this.tlsClient = tlsClient;
         this.tlsClient.init(this);
 
         /*
          * Send Client hello
-         * 
+         *
          * First, generate some random data.
          */
         securityParameters = new SecurityParameters();
@@ -903,7 +917,7 @@ public class TlsProtocolHandler
         while (connection_state != CS_DONE)
         {
             // TODO Should we send fatal alerts in the event of an exception
-            // (see readApplicationData) 
+            // (see readApplicationData)
             rs.readData();
         }
 
@@ -1001,7 +1015,7 @@ public class TlsProtocolHandler
      * Read data from the network. The method will return immediately, if there is still
      * some data left in the buffer, or block until some application data has been read
      * from the network.
-     * 
+     *
      * @param buf The buffer where the data will be copied to.
      * @param offset The position where the data will be placed in the buffer.
      * @param len The maximum number of bytes to read.
@@ -1062,7 +1076,7 @@ public class TlsProtocolHandler
      * Send some application data to the remote system.
      * <p/>
      * The method will handle fragmentation internally.
-     * 
+     *
      * @param buf The buffer with the data.
      * @param offset The position in the buffer where the data is placed.
      * @param len The length of the data.
@@ -1082,7 +1096,7 @@ public class TlsProtocolHandler
 
         /*
          * Protect against known IV attack!
-         * 
+         *
          * DO NOT REMOVE THIS LINE, EXCEPT YOU KNOW EXACTLY WHAT YOU ARE DOING HERE.
          */
         rs.writeMessage(RL_APPLICATION_DATA, emptybuf, 0, 0);
@@ -1143,7 +1157,7 @@ public class TlsProtocolHandler
      * Terminate this connection with an alert.
      * <p/>
      * Can be used for normal closure too.
-     * 
+     *
      * @param alertLevel The level of the alert, an be AL_fatal or AL_warning.
      * @param alertDescription The exact alert message.
      * @throws IOException If alert was fatal.
@@ -1185,13 +1199,13 @@ public class TlsProtocolHandler
         byte[] error = new byte[2];
         error[0] = (byte)alertLevel;
         error[1] = (byte)alertDescription;
-        
+
         rs.writeMessage(RL_ALERT, error, 0, 2);
     }
 
     /**
      * Closes this connection.
-     * 
+     *
      * @throws IOException If something goes wrong during closing.
      */
     public void close() throws IOException
@@ -1204,7 +1218,7 @@ public class TlsProtocolHandler
 
     /**
      * Make sure the InputStream is now empty. Fail otherwise.
-     * 
+     *
      * @param is The InputStream to check.
      * @throws IOException If is is not empty.
      */
@@ -1239,6 +1253,17 @@ public class TlsProtocolHandler
 
 	public void setTrustManagers(TrustManager[] trustManagers) {
 		this.trustManagers = trustManagers;
+	}
+
+	private X509TrustManager chooseTrustManager(TrustManager[] tm) {
+        // We only use the first instance of X509TrustManager passed to us.
+        for (int i = 0; tm != null && i < tm.length; i++) {
+            if (tm[i] instanceof X509TrustManager) {
+                return (X509TrustManager)tm[i];
+            }
+        }
+
+        return null;
 	}
 
 //    private byte[] CreateRenegotiationInfo(byte[] renegotiated_connection) throws IOException

--- a/extended/src/main/java/net/jradius/tls/TlsRSAKeyExchange.java
+++ b/extended/src/main/java/net/jradius/tls/TlsRSAKeyExchange.java
@@ -3,11 +3,10 @@ package net.jradius.tls;
 import java.io.IOException;
 import java.io.InputStream;
 
+import org.bouncycastle.asn1.x509.Certificate;
+import org.bouncycastle.asn1.x509.Extensions;
 import org.bouncycastle.asn1.x509.KeyUsage;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
-import org.bouncycastle.asn1.x509.X509CertificateStructure;
-import org.bouncycastle.asn1.x509.X509Extension;
-import org.bouncycastle.asn1.x509.X509Extensions;
 import org.bouncycastle.crypto.InvalidCipherTextException;
 import org.bouncycastle.crypto.encodings.PKCS1Encoding;
 import org.bouncycastle.crypto.engines.RSABlindedEngine;
@@ -43,7 +42,7 @@ class TlsRSAKeyExchange implements TlsKeyExchange
 
     public void processServerCertificate(CertificateChain serverCertificate) throws IOException
     {
-        X509CertificateStructure x509Cert = serverCertificate.certs[0];
+        Certificate x509Cert = serverCertificate.certs[0];
         SubjectPublicKeyInfo keyInfo = x509Cert.getSubjectPublicKeyInfo();
 
         try
@@ -132,21 +131,17 @@ class TlsRSAKeyExchange implements TlsKeyExchange
         return tmp;
     }
 
-    private void validateKeyUsage(X509CertificateStructure c, int keyUsageBits) throws IOException
+    private void validateKeyUsage(Certificate c, int keyUsageBits) throws IOException
     {
-        X509Extensions exts = c.getTBSCertificate().getExtensions();
+        Extensions exts = c.getTBSCertificate().getExtensions();
         if (exts != null)
         {
-            X509Extension ext = exts.getExtension(X509Extensions.KeyUsage);
-            if (ext != null)
+            KeyUsage ku = KeyUsage.fromExtensions(exts);
+            int bits = ku.getBytes()[0] & 0xff;
+            if ((bits & keyUsageBits) != keyUsageBits)
             {
-                KeyUsage ku = KeyUsage.getInstance(ext);
-                int bits = ku.getBytes()[0] & 0xff;
-                if ((bits & keyUsageBits) != keyUsageBits)
-                {
-                    handler.failWithError(TlsProtocolHandler.AL_fatal,
-                        TlsProtocolHandler.AP_certificate_unknown);
-                }
+                handler.failWithError(TlsProtocolHandler.AL_fatal,
+                    TlsProtocolHandler.AP_certificate_unknown);
             }
         }
     }

--- a/extended/src/main/java/net/jradius/tls/TlsRSAKeyExchange.java
+++ b/extended/src/main/java/net/jradius/tls/TlsRSAKeyExchange.java
@@ -3,7 +3,6 @@ package net.jradius.tls;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.bouncycastle.asn1.DERBitString;
 import org.bouncycastle.asn1.x509.KeyUsage;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.asn1.x509.X509CertificateStructure;
@@ -22,8 +21,8 @@ import org.bouncycastle.crypto.util.PublicKeyFactory;
  */
 class TlsRSAKeyExchange implements TlsKeyExchange
 {
-    private TlsProtocolHandler handler;
-    private CertificateVerifyer verifyer;
+    private final TlsProtocolHandler handler;
+    private final CertificateVerifyer verifyer;
 
     private AsymmetricKeyParameter serverPublicKey = null;
 
@@ -63,7 +62,7 @@ class TlsRSAKeyExchange implements TlsKeyExchange
             handler.failWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_internal_error);
         }
 
-        // TODO 
+        // TODO
         /*
          * Perform various checks per RFC2246 7.4.2: "Unless otherwise specified, the
          * signing algorithm for the certificate must be the same as the algorithm for the
@@ -193,5 +192,9 @@ class TlsRSAKeyExchange implements TlsKeyExchange
         }
 
         return key;
+    }
+
+    public Algorithm getAlgorithm() {
+        return Algorithm.KE_RSA;
     }
 }

--- a/extended/src/main/java/net/jradius/tls/TlsRSAKeyExchange.java
+++ b/extended/src/main/java/net/jradius/tls/TlsRSAKeyExchange.java
@@ -42,7 +42,7 @@ class TlsRSAKeyExchange implements TlsKeyExchange
         handler.failWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_unexpected_message);
     }
 
-    public void processServerCertificate(Certificate serverCertificate) throws IOException
+    public void processServerCertificate(CertificateChain serverCertificate) throws IOException
     {
         X509CertificateStructure x509Cert = serverCertificate.certs[0];
         SubjectPublicKeyInfo keyInfo = x509Cert.getSubjectPublicKeyInfo();

--- a/extended/src/main/java/net/jradius/tls/TlsSRPKeyExchange.java
+++ b/extended/src/main/java/net/jradius/tls/TlsSRPKeyExchange.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
 
-import org.bouncycastle.asn1.DERBitString;
 import org.bouncycastle.asn1.x509.KeyUsage;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.asn1.x509.X509CertificateStructure;
@@ -27,22 +26,22 @@ import org.bouncycastle.util.BigIntegers;
  */
 class TlsSRPKeyExchange implements TlsKeyExchange
 {
-    private TlsProtocolHandler handler;
-    private CertificateVerifyer verifyer;
-    private short keyExchange;
+    private final TlsProtocolHandler handler;
+    private final CertificateVerifyer verifyer;
+    private final Algorithm algorithm;
     private TlsSigner tlsSigner;
 
     private AsymmetricKeyParameter serverPublicKey = null;
 
     // TODO Need a way of providing these
-    private byte[] SRP_identity = null;
-    private byte[] SRP_password = null;
+    private final byte[] SRP_identity = null;
+    private final byte[] SRP_password = null;
 
     private byte[] s = null;
     private BigInteger B = null;
-    private SRP6Client srpClient = new SRP6Client();
+    private final SRP6Client srpClient = new SRP6Client();
 
-    TlsSRPKeyExchange(TlsProtocolHandler handler, CertificateVerifyer verifyer, short keyExchange)
+    TlsSRPKeyExchange(TlsProtocolHandler handler, CertificateVerifyer verifyer, Algorithm keyExchange)
     {
         switch (keyExchange)
         {
@@ -61,7 +60,7 @@ class TlsSRPKeyExchange implements TlsKeyExchange
 
         this.handler = handler;
         this.verifyer = verifyer;
-        this.keyExchange = keyExchange;
+        this.algorithm = keyExchange;
     }
 
     public void skipServerCertificate() throws IOException
@@ -100,15 +99,15 @@ class TlsSRPKeyExchange implements TlsKeyExchange
             handler.failWithError(TlsProtocolHandler.AL_fatal, TlsProtocolHandler.AP_internal_error);
         }
 
-        // TODO 
+        // TODO
         /*
          * Perform various checks per RFC2246 7.4.2: "Unless otherwise specified, the
          * signing algorithm for the certificate must be the same as the algorithm for the
          * certificate key."
          */
-        switch (this.keyExchange)
+        switch (this.algorithm)
         {
-            case TlsKeyExchange.KE_SRP_RSA:
+            case KE_SRP_RSA:
                 if (!(this.serverPublicKey instanceof RSAKeyParameters))
                 {
                     handler.failWithError(TlsProtocolHandler.AL_fatal,
@@ -116,7 +115,7 @@ class TlsSRPKeyExchange implements TlsKeyExchange
                 }
                 validateKeyUsage(x509Cert, KeyUsage.digitalSignature);
                 break;
-            case TlsKeyExchange.KE_SRP_DSS:
+            case KE_SRP_DSS:
                 if (!(this.serverPublicKey instanceof DSAPublicKeyParameters))
                 {
                     handler.failWithError(TlsProtocolHandler.AL_fatal,
@@ -242,5 +241,9 @@ class TlsSRPKeyExchange implements TlsKeyExchange
         signer.update(securityParameters.clientRandom, 0, securityParameters.clientRandom.length);
         signer.update(securityParameters.serverRandom, 0, securityParameters.serverRandom.length);
         return signer;
+    }
+
+    public Algorithm getAlgorithm() {
+        return algorithm;
     }
 }

--- a/extended/src/main/java/net/jradius/tls/TlsSRPKeyExchange.java
+++ b/extended/src/main/java/net/jradius/tls/TlsSRPKeyExchange.java
@@ -73,7 +73,7 @@ class TlsSRPKeyExchange implements TlsKeyExchange
         }
     }
 
-    public void processServerCertificate(Certificate serverCertificate) throws IOException
+    public void processServerCertificate(CertificateChain serverCertificate) throws IOException
     {
         if (tlsSigner == null)
         {


### PR DESCRIPTION
Reviewer: @wlanmac 

This addresses part of my concern raised in https://github.com/coova/jradius/issues/23
I personally only have use for EAP-TTLS so I have no need to send client certificates. 

In short, this performs server certificate verification upon receipt of a certificate during the handshake when a valid `X509TrustManager` can be found.  In order to verify the server certificate dynamically I had to pass the key exchange algorithm into the trust manager. I extended the `KeyExchange` interface and created enum values instead of static integers. This allows the enum to hold a name string as well as the integer value. The name string is what is passed to the trust manager dynamically. 

I also made some changes to how the `KeyUsage` object was constructed in the `KeyExchange` implementations since I was getting an IllegalArgumentException during testing. I updated some of the bouncy castle classes so that I could leverage `KeyUsage.fromExtensions`. This seemed to alleviate the problem.

