### PR TITLE
Fix: Source/Target option 5 is no longer supported

### DIFF
--- a/dictionary-min/pom.xml
+++ b/dictionary-min/pom.xml
@@ -29,8 +29,8 @@
 	<groupId>org.apache.maven.plugins</groupId>
 	<artifactId>maven-compiler-plugin</artifactId>
 	<configuration>
-	  <source>1.5</source>
-	  <target>1.5</target>
+	  <source>1.6</source>
+	  <target>1.6</target>
 	</configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
jradius-dictionary-min: Compilation failure: Compilation failure:  [ERROR] Source option 5 is no longer supported. Use 6 or later. [ERROR] Target option 1.5 is no longer supported. Use 1.6 or later.